### PR TITLE
Added non engine exclude paths to the code climate config.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -13,7 +13,9 @@ engines:
         rulesets: "codesize,design,unusedcode"
 exclude_paths:
   - "tests/**/*"
+  - "tests/*"
   - "vendor/**/*"
+  - "vendor/*"
 ratings:
   paths:
     - "**.php"


### PR DESCRIPTION
Code climate is still analysing the tests directory, I hope this might
now stop that.